### PR TITLE
To fix error i got

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker exec -it ${container_id} /bin/bash
 ### Initialize the web front end
 
 ```bash
-cd /app/client/ && yarn install && yarn build
+cd /app/client/ && yarn add sass && yarn install && yarn build
 ```
 
 ### Initialize the API


### PR DESCRIPTION
when I tried to build it I got problem of:
```log
bash-5.1# cd /app/client/ && yarn install && yarn build
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > mobx-react-devtools@5.0.1" has incorrect peer dependency "mobx@^4.0.0".
warning "react-avatar-editor > @babel/plugin-transform-runtime@7.15.0" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "react-avatar-editor > @babel/plugin-transform-runtime > babel-plugin-polyfill-corejs2@0.2.2" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "react-avatar-editor > @babel/plugin-transform-runtime > babel-plugin-polyfill-corejs3@0.2.4" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "react-avatar-editor > @babel/plugin-transform-runtime > babel-plugin-polyfill-regenerator@0.2.2" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "react-avatar-editor > @babel/plugin-transform-runtime > babel-plugin-polyfill-corejs2 > @babel/helper-define-polyfill-provider@0.2.3" has unmet peer dependency "@babel/core@^7.4.0-0".
warning " > react-medium-image-zoom@3.1.3" has unmet peer dependency "prop-types@^15.5.8".
warning "react-scripts > @typescript-eslint/eslint-plugin > tsutils@3.21.0" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
warning "@babel/plugin-proposal-decorators > @babel/helper-create-class-features-plugin@7.15.0" has unmet peer dependency "@babel/core@^7.0.0".
warning "@babel/plugin-proposal-decorators > @babel/plugin-syntax-decorators@7.14.5" has unmet peer dependency "@babel/core@^7.0.0-0".
warning " > @babel/plugin-proposal-decorators@7.14.5" has unmet peer dependency "@babel/core@^7.0.0-0".
[4/4] Building fresh packages...
[-/9] ⢀ waiting...
[8/9] ⢀ node-sass
[9/9] ⢀ web3
[-/9] ⢀ waiting...
error /app/client/node_modules/node-sass: Command failed.
Exit code: 1
Command: node scripts/build.js
Arguments: 
Directory: /app/client/node_modules/node-sass
Output:
Building: /usr/bin/node /app/client/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
gyp info it worked if it ends with ok
gyp verb cli [
gyp verb cli   '/usr/bin/node',
gyp verb cli   '/app/client/node_modules/node-gyp/bin/node-gyp.js',
gyp verb cli   'rebuild',
gyp verb cli   '--verbose',
gyp verb cli   '--libsass_ext=',
gyp verb cli   '--libsass_cflags=',
gyp verb cli   '--libsass_ldflags=',
gyp verb cli   '--libsass_library='
gyp verb cli ]
gyp info using node-gyp@3.8.0
gyp info using node@18.9.1 | linux | x64
gyp verb command rebuild []
gyp verb command clean []
gyp verb clean removing "build" directory
gyp verb command configure []
gyp verb check python checking for Python executable "python2" in the PATH
gyp verb `which` failed Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/app/client/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/app/client/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/app/client/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /app/client/node_modules/which/which.js:89:16
gyp verb `which` failed     at /app/client/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /app/client/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (node:fs:211:21)
gyp verb `which` failed  python2 Error: not found: python2
gyp verb `which` failed     at getNotFoundError (/app/client/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/app/client/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/app/client/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /app/client/node_modules/which/which.js:89:16
gyp verb `which` failed     at /app/client/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /app/client/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (node:fs:211:21) {
gyp verb `which` failed   code: 'ENOENT'
gyp verb `which` failed }
gyp verb check python checking for Python executable "python" in the PATH
gyp verb `which` failed Error: not found: python
gyp verb `which` failed     at getNotFoundError (/app/client/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/app/client/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/app/client/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /app/client/node_modules/which/which.js:89:16
gyp verb `which` failed     at /app/client/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /app/client/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (node:fs:211:21)
gyp verb `which` failed  python Error: not found: python
gyp verb `which` failed     at getNotFoundError (/app/client/node_modules/which/which.js:13:12)
gyp verb `which` failed     at F (/app/client/node_modules/which/which.js:68:19)
gyp verb `which` failed     at E (/app/client/node_modules/which/which.js:80:29)
gyp verb `which` failed     at /app/client/node_modules/which/which.js:89:16
gyp verb `which` failed     at /app/client/node_modules/isexe/index.js:42:5
gyp verb `which` failed     at /app/client/node_modules/isexe/mode.js:8:5
gyp verb `which` failed     at FSReqCallback.oncomplete (node:fs:211:21) {
gyp verb `which` failed   code: 'ENOENT'
gyp verb `which` failed }
gyp ERR! configure error 
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (/app/client/node_modules/node-gyp/lib/configure.js:484:19)
gyp ERR! stack     at PythonFinder.<anonymous> (/app/client/node_modules/node-gyp/lib/configure.js:406:16)
gyp ERR! stack     at F (/app/client/node_modules/which/which.js:68:16)
gyp ERR! stack     at E (/app/client/node_modules/which/which.js:80:29)
gyp ERR! stack     at /app/client/node_modules/which/which.js:89:16
gyp ERR! stack     at /app/client/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /app/client/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqCallback.oncomplete (node:fs:211:21)
gyp ERR! System Linux 5.10.0-19-amd64
gyp ERR! command "/usr/bin/node" "/app/client/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /app/client/node_modules/node-sass
gyp ERR! node -v v18.9.1




bash-5.1# 

```
and to fix it, I followed: https://stackoverflow.com/a/62495377